### PR TITLE
Update broken link to OAuth page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ cp server/config_example.js server/config.js
 $ npm install
 ```
 
-Replace the `clientID`, `clientSecret`, `callbackURL` values in `server/config.js` appropriately after applying for OAuth client details [here](https://app.intercom.io/a/apps/_/settings/oauth).
+Replace the `clientID`, `clientSecret`, `callbackURL` values in `server/config.js` appropriately after applying for OAuth client details that you can find in an app's details page in the [Developer Hub](https://app.intercom.io/a/apps/_/developer-hub).
 
 Modify the MongoDB connection URL in `server/app.js` if necessary.
 


### PR DESCRIPTION
When reading the README, I noticed that a URL that takes us to `/settings/oauth` doesn't work anymore. As far as I know, these settings now live in an app's details page in the Developer Hub.